### PR TITLE
fix mix-up in setting gurobi gap parameter

### DIFF
--- a/GurobiBackend.cpp
+++ b/GurobiBackend.cpp
@@ -240,9 +240,9 @@ GurobiBackend::solve(Solution& x, std::string& msg) {
 
 		GRBenv* modelenv = GRBgetenv(_model);
 		if (_absoluteGap)
-			GRB_CHECK(GRBsetdblparam(modelenv, GRB_DBL_PAR_MIPGAP, _gap));
-		else
 			GRB_CHECK(GRBsetdblparam(modelenv, GRB_DBL_PAR_MIPGAPABS, _gap));
+		else
+			GRB_CHECK(GRBsetdblparam(modelenv, GRB_DBL_PAR_MIPGAP, _gap));
 
 		LOG_USER(gurobilog)
 				<< "using " << (_absoluteGap ? "absolute" : "relative")


### PR DESCRIPTION
parameter keys for relative and absolute gap were mixed up

@funkey 