### PR TITLE
add definition to turn on/off verbose logging in solver backend

### DIFF
--- a/LinearSolverBackend.h
+++ b/LinearSolverBackend.h
@@ -97,7 +97,7 @@ public:
 	 * Turn verbose logging on or off.
 	 *
 	 * @param verbose
-	 *             If set to true, verbose logging is enabled..
+	 *             If set to true, verbose logging is enabled.
 	 */
         virtual void setVerbose(bool verbose) = 0;
 

--- a/LinearSolverBackend.h
+++ b/LinearSolverBackend.h
@@ -94,6 +94,14 @@ public:
 	virtual void setNumThreads(unsigned int numThreads) = 0;
 
 	/**
+	 * Turn verbose logging on or off.
+	 *
+	 * @param verbose
+	 *             If set to true, verbose logging is enabled..
+	 */
+        virtual void setVerbose(bool verbose) = 0;
+
+	/**
 	 * Solve the problem.
 	 *
 	 * @param solution A solution object to write the solution to.


### PR DESCRIPTION
the setVerbose functions are already present in the backends,
but not exposed to pylp through the LinearSolverBackend base class.

@funkey 